### PR TITLE
Refactor: Remove home navigation from login screen

### DIFF
--- a/app/src/main/java/com/flareframe/ui/screens/ScaffoldScreen.kt
+++ b/app/src/main/java/com/flareframe/ui/screens/ScaffoldScreen.kt
@@ -125,9 +125,7 @@ fun AppScaffold(
                 LoginScreen(
                     modifier = Modifier,
                     userViewModel = loginViewModel,
-                    onNavigateToHome = {
-                        navController.navigate(route = Home)
-                    },
+
                     onRegister = { navController.navigate(route = Register) })   // add logic for home page
             }
             composable<Loading> { LoadingScreen() }


### PR DESCRIPTION
The `onNavigateToHome` callback and its associated navigation logic have been removed from the `LoginScreen`. This suggests that navigation to the home screen after login is now handled elsewhere in the application.