### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/feature-branch-checks.yml
+++ b/.github/workflows/feature-branch-checks.yml
@@ -1,4 +1,6 @@
 name: Build and Test on Push (All Branches Except Main)
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Flare-Frame/Flare-Frame/security/code-scanning/1](https://github.com/Flare-Frame/Flare-Frame/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow primarily interacts with repository contents (e.g., checking out code, caching dependencies, and running tests), the minimal required permission is `contents: read`. This ensures the workflow adheres to the principle of least privilege.

The `permissions` block should be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
