### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-main.yml
+++ b/.github/workflows/manual-main.yml
@@ -1,6 +1,9 @@
 name: Generated APK AAB (Upload - Create Artifact To Github Action)
 
 # Define environment variables used throughout the workflow
+permissions:
+  contents: read
+  actions: read
 env:
   main_project_module: app # The name of the main module repository
   playstore_name: Flare-Frame # The name of the Play Store app (only for naming artifacts)


### PR DESCRIPTION
Potential fix for [https://github.com/Flare-Frame/Flare-Frame/security/code-scanning/2](https://github.com/Flare-Frame/Flare-Frame/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the minimal permissions required are likely `contents: read` for accessing repository contents and `actions: read` for interacting with GitHub Actions artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job. Since the workflow only contains one job (`build`), adding the permissions at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
