### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual-main.yml
+++ b/.github/workflows/manual-main.yml
@@ -9,6 +9,9 @@ on:
     branches: [main]      # …against main
   workflow_dispatch:      # Allow manual triggering anytime
 
+permissions:
+  contents: read
+
 jobs:
   release-build:
     name: Build Release + Debug Artifacts


### PR DESCRIPTION
Potential fix for [https://github.com/Flare-Frame/Flare-Frame/security/code-scanning/3](https://github.com/Flare-Frame/Flare-Frame/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow (`actions/checkout` and `actions/upload-artifact`), the workflow only requires `contents: read` permissions. Adding this block at the root level ensures that all jobs in the workflow inherit these permissions unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
